### PR TITLE
fix unresolved method in case of MappingDriverChain configuration

### DIFF
--- a/src/Factory/AbstractFieldsConfigurationFactory.php
+++ b/src/Factory/AbstractFieldsConfigurationFactory.php
@@ -125,16 +125,16 @@ abstract class AbstractFieldsConfigurationFactory
     protected function getAnnotationReader(): Reader
     {
         $driver = $this->entityManager->getConfiguration()->getMetadataDriverImpl();
-        if ($driver instanceof MappingDriverChain::class) {
+        if ($driver instanceof MappingDriverChain) {
             $drivers = $driver->getDrivers();
             foreach ($drivers as $driver) {
-                if ($driver instanceof AnnotationDriver::class) {
+                if ($driver instanceof AnnotationDriver) {
                     break;
                 }
             }
         }
         
-        if ($driver instanceof AnnotationDriver::class) {
+        if ($driver instanceof AnnotationDriver) {
             return $driver->getReader();
         }
         

--- a/src/Factory/AbstractFieldsConfigurationFactory.php
+++ b/src/Factory/AbstractFieldsConfigurationFactory.php
@@ -125,15 +125,19 @@ abstract class AbstractFieldsConfigurationFactory
     protected function getAnnotationReader(): Reader
     {
         $driver = $this->entityManager->getConfiguration()->getMetadataDriverImpl();
-        if (is_a($driver, MappingDriverChain::class)) {
+        if ($driver instanceof MappingDriverChain::class) {
             $drivers = $driver->getDrivers();
             foreach ($drivers as $driver) {
-                if (is_a($driver, AnnotationDriver::class))
-                    return $driver->getReader();
+                if ($driver instanceof AnnotationDriver::class) {
+                    break;
+                }
             }
         }
-        if (method_exists($driver, 'getReader'))
+        
+        if ($driver instanceof AnnotationDriver::class) {
             return $driver->getReader();
+        }
+        
         return new AnnotationReader();
     }
 

--- a/src/Factory/AbstractFieldsConfigurationFactory.php
+++ b/src/Factory/AbstractFieldsConfigurationFactory.php
@@ -133,11 +133,11 @@ abstract class AbstractFieldsConfigurationFactory
                 }
             }
         }
-        
+
         if ($driver instanceof AnnotationDriver) {
             return $driver->getReader();
         }
-        
+
         return new AnnotationReader();
     }
 


### PR DESCRIPTION
in my symfony configuration current version fails when trying to explicitly call "getReader" of an object, which turns out to be a MappingDriverChain object instead of expected AnnotationDriver, I suppose