### PR TITLE
Field resolver fix

### DIFF
--- a/src/DefaultFieldResolver.php
+++ b/src/DefaultFieldResolver.php
@@ -70,11 +70,11 @@ class DefaultFieldResolver
      */
     private function getGetter($source, string $name): ?ReflectionMethod
     {
-        if (!preg_match('~^(is|has)[A-Z]~', $name)) {
-            $name = 'get' . ucfirst($name);
-        }
-
         $class = new ReflectionClass($source);
+
+        if (!preg_match('~^(is|has)[A-Z]~', $name) ||  !$class->hasMethod($name))
+            $name = 'get' . ucfirst($name);
+
         if ($class->hasMethod($name)) {
             $method = $class->getMethod($name);
             if ($method->getModifiers() & ReflectionMethod::IS_PUBLIC) {

--- a/src/Factory/AbstractFieldsConfigurationFactory.php
+++ b/src/Factory/AbstractFieldsConfigurationFactory.php
@@ -125,16 +125,16 @@ abstract class AbstractFieldsConfigurationFactory
     protected function getAnnotationReader(): Reader
     {
         $driver = $this->entityManager->getConfiguration()->getMetadataDriverImpl();
-        if ($driver instanceof MappingDriverChain::class) {
+        if ($driver instanceof MappingDriverChain) {
             $drivers = $driver->getDrivers();
             foreach ($drivers as $driver) {
-                if ($driver instanceof AnnotationDriver::class) {
+                if ($driver instanceof AnnotationDriver) {
                     break;
                 }
             }
         }
         
-        if ($driver instanceof AnnotationDriver::class) {
+        if ($driver instanceof AnnotationDriver) {
             return $driver->getReader();
         }
         

--- a/src/Factory/AbstractFieldsConfigurationFactory.php
+++ b/src/Factory/AbstractFieldsConfigurationFactory.php
@@ -125,15 +125,19 @@ abstract class AbstractFieldsConfigurationFactory
     protected function getAnnotationReader(): Reader
     {
         $driver = $this->entityManager->getConfiguration()->getMetadataDriverImpl();
-        if (is_a($driver, MappingDriverChain::class)) {
+        if ($driver instanceof MappingDriverChain::class) {
             $drivers = $driver->getDrivers();
             foreach ($drivers as $driver) {
-                if (is_a($driver, AnnotationDriver::class))
-                    return $driver->getReader();
+                if ($driver instanceof AnnotationDriver::class) {
+                    break;
+                }
             }
         }
-        if (method_exists($driver, 'getReader'))
+        
+        if ($driver instanceof AnnotationDriver::class) {
             return $driver->getReader();
+        }
+        
         return new AnnotationReader();
     }
 

--- a/src/Factory/AbstractFieldsConfigurationFactory.php
+++ b/src/Factory/AbstractFieldsConfigurationFactory.php
@@ -133,11 +133,11 @@ abstract class AbstractFieldsConfigurationFactory
                 }
             }
         }
-        
+
         if ($driver instanceof AnnotationDriver) {
             return $driver->getReader();
         }
-        
+
         return new AnnotationReader();
     }
 


### PR DESCRIPTION
Somehow it's not clear that having the library forces to have a specific getter name for field named like "is_active" . In my case it's still "getIsActive()" but not "isActive()". Fixed it so it works with both conventions