### PR TITLE
require webonyx/graphql-php ~0.11.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
         }
     },
     "require": {
-        "doctrine/orm": "^2.5",
         "php": "^7.1",
-        "webonyx/graphql-php": "^0.11.5"
+        "doctrine/orm": "^2.5",
+        "webonyx/graphql-php": "~0.11.5"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "@stable",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "298729b544f483a7a3e5710bedfe6b77",
+    "content-hash": "52ae47ba6f35d7d118e243058e132efe",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -1214,6 +1214,9 @@
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause|MIT"
+            ],
             "authors": [
                 {
                     "name": "Kore Nordmann",


### PR DESCRIPTION
fixup #7

[Caret Version Range (^)](https://getcomposer.org/doc/articles/versions.md#caret-version-range-) has special limitation that treats pre-1.0 versions differently.

as with current releases, i had to downgrade webonyx/graphql-php to be able to use ecodev/graphql-doctrine 1.1.0 release.

```
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for ecodev/graphql-doctrine ^1.1 -> satisfiable by ecodev/graphql-doctrine[1.1.0].
    - ecodev/graphql-doctrine 1.1.0 requires webonyx/graphql-php ^0.10.1 -> satisfiable by webonyx/graphql-php[v0.10.1, v0.10.2] but these conflict with your requirements or minimum-stability.
```

while this problem can be solved by just tagging new version, it should fix similar issue in the future.