### PR TITLE
Renamed script 'check' to 'ci-check' 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "keywords": ["api", "graphql", "doctrine", "doctrine-orm"],
     "scripts": {
-        "check": [
+        "ci-check": [
             "php-cs-fixer fix --ansi --dry-run --diff",
             "phpunit --color=always"
         ],


### PR DESCRIPTION
Renamed script 'check' to 'ci-check' because 'check' is an existing command in composer itself