### PR TITLE
Update README.md for getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ use Zend\ServiceManager\ServiceManager;
 $customTypes = new ServiceManager([
     'invokables' => [
         DateTime::class => DateTimeType::class,
+        'datetime' => DateTimeType::class,
         'PostStatus' => PostStatusType::class,
     ],
 ]);


### PR DESCRIPTION
Following the example code, I get this error:

```
PHP Fatal error:  Uncaught GraphQL\Doctrine\Exception: No type registered with key `datetime`. Either correct the usage, or register it in your custom types container when instantiating `GraphQL\Doctrine\Types`.
```

I think it is important to include `'datetime' => DateTimeType::class` for new users.

