### PR TITLE
Update DocBlockReader.php - Resolves issue on No type registered

### DIFF
--- a/src/DocBlockReader.php
+++ b/src/DocBlockReader.php
@@ -86,7 +86,7 @@ final class DocBlockReader
     public function getReturnType(): ?string
     {
         if (preg_match('~@return\h+(\H+)(\h|\n)~', $this->comment, $m)) {
-            return trim($m[1]);
+            return ltrim(trim($m[1]), '\\');
         }
 
         return null;


### PR DESCRIPTION
Resolves issue on `No type registered with key '\DateTime'.`

The error below is encountered when the getter method is like this:

```
/**
 * @return \DateTime
 */
public function getDatetimeUsageStart()
{
    return $this->datetime_usage_start;
}
```

This one below works fine:
```
/**
 * @return DateTime
 */
public function getDatetimeUsageStart()
{
    return $this->datetime_usage_start;
}
```

Also, This one below works fine:
```
public function getDatetimeUsageStart(): \DateTime
{
    return $this->datetime_usage_start;
}
```

Although it can be fixed just by removing the leading backward-slash, It is best to get this fixed this way because there are third-party libraries that we can't edit and having traits like this.

ERROR: 
```
PHP Fatal error:  Uncaught GraphQL\Doctrine\Exception: No type registered with key `\DateTime`. Either correct the usage, or register it in your custom types container when instantiating `GraphQL\Doctrine\Types`.
```