### PR TITLE
Fix - Resolves issue on No type registered

### DIFF
--- a/src/Factory/Type/FilterGroupConditionTypeFactory.php
+++ b/src/Factory/Type/FilterGroupConditionTypeFactory.php
@@ -58,8 +58,20 @@ final class FilterGroupConditionTypeFactory extends AbstractTypeFactory
                 // Get custom operators
                 $this->readCustomOperatorsFromAnnotation($metadata->reflClass);
 
+                // This will convert 'datetime' string to 'DateTime'
+                $fieldMappings = array_map(function($mapping){
+                    switch ($mapping['type']) {
+                        case 'datetime': {
+                            $mapping['type'] = 'DateTime';
+                            break;
+                        }
+                    }
+                    
+                    return $mapping;
+                }, $metadata->fieldMappings);
+
                 // Get all scalar fields
-                foreach ($metadata->fieldMappings as $mapping) {
+                foreach ($fieldMappings as $mapping) {
                     if ($mapping['id'] ?? false) {
                         $leafType = Type::id();
                     } else {


### PR DESCRIPTION
Resolves issue on No type registered with key 'datetime'.

The error below is encountered when `filter` is added:

```
[
    'name' => 'filter',
    'type' => $types->getFilter(Post::class), // Use automated filtering options
]
```

ERROR:
```
PHP Fatal error:  Uncaught GraphQL\Doctrine\Exception: No type registered with key `datetime`. Either correct the usage, or register it in your custom types container when instantiating `GraphQL\Doctrine\Types`.
```