### PR TITLE
PHP 8 attribute support

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,14 +5,14 @@ parameters:
         - tests/
     excludePaths:
         - tests/Blog/Model/*
+        - tests/AttributeBlog/Model/*
     checkMissingIterableValueType: false
     checkGenericClassInNonGenericObjectType: false
     ignoreErrors:
-        - '~^Property GraphQL\\Doctrine\\Annotation\\Field::\$type \(string\) does not accept GraphQL\\Type\\Definition\\~'
-        - '~^Instanceof between string and GraphQL\\Type\\Definition\\Type will always evaluate to false\.$~'
+        - '~^Property GraphQL\\Doctrine\\Annotation\\Field::\$type \(string\|null\) does not accept GraphQL\\Type\\Definition\\~'
+        - '~^Instanceof between string\|null and GraphQL\\Type\\Definition\\Type will always evaluate to false\.$~'
         - '~^Parameter #1 \$wrappedType of static method GraphQL\\Type\\Definition\\Type::~'
         - '~^Parameter #2 \$type of static method GraphQL\\Doctrine\\Utils::getOperatorTypeName~'
-        - '~Property GraphQL\\Doctrine\\Annotation\\Field::\$description \(string\) does not accept string\|null\.$~'
         - '~^Parameter #1 \$method of method GraphQL\\Doctrine\\Factory\\AbstractFieldsConfigurationFactory\:\:getMethodFullName\(\) expects ReflectionMethod, ReflectionFunctionAbstract given\.$~'
         - '~^Parameter #3 \$subject of function preg_replace expects array\|string, string\|null given\.$~'
         - '~^Parameter #2 \$type of method GraphQL\\Doctrine\\Factory\\AbstractFactory::adjustNamespace\(\) expects string, string\|null given\.$~'

--- a/src/Annotation/Argument.php
+++ b/src/Annotation/Argument.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace GraphQL\Doctrine\Annotation;
 
 /**
- * Annotation used to override values for an field argument in GraphQL.
+ * Annotation used to override values for a field argument in GraphQL.
  *
  * The name of the argument is required and must match the actual PHP argument name.
  *

--- a/src/Annotation/Argument.php
+++ b/src/Annotation/Argument.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace GraphQL\Doctrine\Annotation;
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
+
 /**
  * Annotation used to override values for a field argument in GraphQL.
  *
@@ -13,7 +15,7 @@ namespace GraphQL\Doctrine\Annotation;
  * what is declared by the original argument of the method.
  *
  * @Annotation
- *
+ * @NamedArgumentConstructor
  * @Target({"ANNOTATION"})
  * @Attributes({
  *     @Attribute("name", required=true, type="string"),
@@ -24,4 +26,23 @@ namespace GraphQL\Doctrine\Annotation;
  */
 final class Argument extends AbstractAnnotation
 {
+    private const NO_VALUE_PASSED = '_hacky_no_value_past_find_a_better_solution_for_this_';
+
+    public function __construct(
+        string $name,
+        ?string $type = null,
+        ?string $description = null,
+        mixed $defaultValue = self::NO_VALUE_PASSED
+    ) {
+        $settings = [
+            'name' => $name,
+            'type' => $type,
+            'description' => $description,
+        ];
+        if ($defaultValue !== self::NO_VALUE_PASSED) {
+            $settings['defaultValue'] = $defaultValue;
+        }
+
+        parent::__construct($settings);
+    }
 }

--- a/src/Annotation/Exclude.php
+++ b/src/Annotation/Exclude.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace GraphQL\Doctrine\Annotation;
 
+use Attribute;
+
 /**
  * Annotation used to exclude a method from GraphQL fields, or a property from GraphQL filters.
  *
@@ -13,6 +15,7 @@ namespace GraphQL\Doctrine\Annotation;
  *
  * @Target({"METHOD", "PROPERTY"})
  */
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_PROPERTY)]
 final class Exclude
 {
 }

--- a/src/Annotation/Field.php
+++ b/src/Annotation/Field.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace GraphQL\Doctrine\Annotation;
 
+use Attribute;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
+use Doctrine\ORM\Mapping\Annotation;
+
 /**
  * Annotation used to override values for an output field in GraphQL.
  *
@@ -11,25 +15,26 @@ namespace GraphQL\Doctrine\Annotation;
  * what is declared by the original method.
  *
  * @Annotation
- *
+ * @NamedArgumentConstructor
  * @Target({"METHOD"})
  */
-final class Field
+#[Attribute(Attribute::TARGET_METHOD)]
+final class Field implements Annotation
 {
     /**
-     * @var string
+     * @var null|string
      */
     public $name;
 
     /**
      * FQCN of PHP class implementing the GraphQL type.
      *
-     * @var string
+     * @var null|string
      */
     public $type;
 
     /**
-     * @var string
+     * @var null|string
      */
     public $description;
 
@@ -37,6 +42,18 @@ final class Field
      * @var array<\GraphQL\Doctrine\Annotation\Argument>
      */
     public $args = [];
+
+    public function __construct(
+        ?string $name = null,
+        ?string $type = null,
+        ?string $description = null,
+        array $args = []
+    ) {
+        $this->name = $name;
+        $this->type = $type;
+        $this->description = $description;
+        $this->args = $args;
+    }
 
     public function toArray(): array
     {

--- a/src/Annotation/Filter.php
+++ b/src/Annotation/Filter.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace GraphQL\Doctrine\Annotation;
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
+
 /**
  * Annotation used to override values for an field argument in GraphQL.
  *
@@ -13,7 +15,7 @@ namespace GraphQL\Doctrine\Annotation;
  * what is declared by the original argument of the method.
  *
  * @Annotation
- *
+ * @NamedArgumentConstructor
  * @Target({"ANNOTATION"})
  */
 final class Filter
@@ -47,4 +49,11 @@ final class Filter
      * @Required
      */
     public $type;
+
+    public function __construct(string $field, string $operator, string $type)
+    {
+        $this->field = $field;
+        $this->operator = $operator;
+        $this->type = $type;
+    }
 }

--- a/src/Annotation/FilterGroupCondition.php
+++ b/src/Annotation/FilterGroupCondition.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GraphQL\Doctrine\Annotation;
 
 use Attribute;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
 /**
  * Annotation used to override values for a filterGroupCondition in GraphQL.
@@ -13,7 +14,7 @@ use Attribute;
  * a custom GraphQL type.
  *
  * @Annotation
- *
+ * @NamedArgumentConstructor
  * @Target({"PROPERTY"})
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
@@ -25,4 +26,9 @@ final class FilterGroupCondition
      * @Required
      */
     public string $type;
+
+    public function __construct(string $type)
+    {
+        $this->type = $type;
+    }
 }

--- a/src/Annotation/FilterGroupCondition.php
+++ b/src/Annotation/FilterGroupCondition.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace GraphQL\Doctrine\Annotation;
 
+use Attribute;
+
 /**
  * Annotation used to override values for a filterGroupCondition in GraphQL.
  *
@@ -14,14 +16,13 @@ namespace GraphQL\Doctrine\Annotation;
  *
  * @Target({"PROPERTY"})
  */
+#[Attribute(Attribute::TARGET_PROPERTY)]
 final class FilterGroupCondition
 {
     /**
      * FQCN of PHP class implementing the GraphQL type.
      *
-     * @var string
-     *
      * @Required
      */
-    public $type;
+    public string $type;
 }

--- a/src/Annotation/Filters.php
+++ b/src/Annotation/Filters.php
@@ -4,13 +4,17 @@ declare(strict_types=1);
 
 namespace GraphQL\Doctrine\Annotation;
 
+use Attribute;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
+
 /**
  * Annotation used to define custom filters.
  *
  * @Annotation
- *
+ * @NamedArgumentConstructor
  * @Target({"CLASS"})
  */
+#[Attribute(Attribute::TARGET_CLASS)]
 final class Filters
 {
     /**
@@ -20,5 +24,13 @@ final class Filters
      *
      * @Required
      */
-    public $filters = [];
+    public array $filters = [];
+
+    /**
+     * @param array<Filter> $filters
+     */
+    public function __construct(array $filters)
+    {
+        $this->filters = $filters;
+    }
 }

--- a/src/Annotation/Input.php
+++ b/src/Annotation/Input.php
@@ -23,6 +23,7 @@ use Doctrine\Common\Annotations\Annotation\Attributes;
  *     @Attribute("defaultValue", required=false, type="mixed"),
  * })
  */
+#[\Attribute(\Attribute::TARGET_METHOD)]
 final class Input extends AbstractAnnotation
 {
 }

--- a/src/Annotation/Input.php
+++ b/src/Annotation/Input.php
@@ -6,6 +6,7 @@ namespace GraphQL\Doctrine\Annotation;
 
 use Doctrine\Common\Annotations\Annotation\Attribute;
 use Doctrine\Common\Annotations\Annotation\Attributes;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
 /**
  * Annotation used to override values for an input field in GraphQL.
@@ -14,7 +15,7 @@ use Doctrine\Common\Annotations\Annotation\Attributes;
  * what is declared by the original method.
  *
  * @Annotation
- *
+ * @NamedArgumentConstructor
  * @Target({"METHOD"})
  * @Attributes({
  *     @Attribute("name", required=false, type="string"),
@@ -26,4 +27,23 @@ use Doctrine\Common\Annotations\Annotation\Attributes;
 #[\Attribute(\Attribute::TARGET_METHOD)]
 final class Input extends AbstractAnnotation
 {
+    private const NO_VALUE_PASSED = '_hacky_no_value_past_find_a_better_solution_for_this_';
+
+    public function __construct(
+        ?string $name = null,
+        ?string $type = null,
+        ?string $description = null,
+        mixed $defaultValue = self::NO_VALUE_PASSED
+    ) {
+        $settings = [
+            'name' => $name,
+            'type' => $type,
+            'description' => $description,
+        ];
+        if ($defaultValue !== self::NO_VALUE_PASSED) {
+            $settings['defaultValue'] = $defaultValue;
+        }
+
+        parent::__construct($settings);
+    }
 }

--- a/src/Annotation/Sorting.php
+++ b/src/Annotation/Sorting.php
@@ -4,13 +4,17 @@ declare(strict_types=1);
 
 namespace GraphQL\Doctrine\Annotation;
 
+use Attribute;
+use GraphQL\Doctrine\Sorting\SortingInterface;
+
 /**
  * Annotation used to define custom sorting.
  *
  * @Annotation
- *
+ * @NamedArgumentConstructor
  * @Target({"CLASS"})
  */
+#[Attribute(Attribute::TARGET_CLASS)]
 final class Sorting
 {
     /**
@@ -18,5 +22,13 @@ final class Sorting
      *
      * @var array<string>
      */
-    public $classes = [];
+    public array $classes = [];
+
+    /**
+     * @param array<string> $classes
+     */
+    public function __construct(array $classes)
+    {
+        $this->classes = $classes;
+    }
 }

--- a/src/Factory/MetadataReader/AttributeReaderAdapter.php
+++ b/src/Factory/MetadataReader/AttributeReaderAdapter.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQL\Doctrine\Factory\MetadataReader;
+
+use Doctrine\Common\Annotations\Reader;
+use Doctrine\ORM\Mapping\Driver\AttributeReader;
+use Doctrine\ORM\Mapping\Driver\RepeatableAttributeCollection;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionProperty;
+
+final class AttributeReaderAdapter implements Reader
+{
+    private AttributeReader $attributeReader;
+
+    public function __construct(AttributeReader $attributeReader)
+    {
+        $this->attributeReader = $attributeReader;
+    }
+
+    public function getClassAnnotations(ReflectionClass $class)
+    {
+        return $this->attributeReader->getClassAnnotations($class);
+    }
+
+    public function getClassAnnotation(ReflectionClass $class, $annotationName)
+    {
+        $result = $this->attributeReader->getClassAnnotation($class, $annotationName);
+        if ($result instanceof RepeatableAttributeCollection) {
+            $result = $result[0];
+        }
+
+        assert($result instanceof $annotationName);
+
+        return $result;
+    }
+
+    public function getMethodAnnotations(ReflectionMethod $method)
+    {
+        return $this->attributeReader->getMethodAnnotations($method);
+    }
+
+    public function getMethodAnnotation(ReflectionMethod $method, $annotationName)
+    {
+        $result = $this->attributeReader->getMethodAnnotation($method, $annotationName);
+        if ($result instanceof RepeatableAttributeCollection) {
+            $result = $result[0];
+        }
+
+        assert($result instanceof $annotationName);
+
+        return $result;
+    }
+
+    public function getPropertyAnnotations(ReflectionProperty $property)
+    {
+        return $this->attributeReader->getPropertyAnnotations($property);
+    }
+
+    public function getPropertyAnnotation(ReflectionProperty $property, $annotationName)
+    {
+        $result = $this->attributeReader->getPropertyAnnotation($property, $annotationName);
+        if ($result instanceof RepeatableAttributeCollection) {
+            $result = $result[0];
+        }
+
+        assert($result instanceof $annotationName);
+
+        return $result;
+    }
+}

--- a/src/Factory/OutputFieldsConfigurationFactory.php
+++ b/src/Factory/OutputFieldsConfigurationFactory.php
@@ -82,7 +82,7 @@ final class OutputFieldsConfigurationFactory extends AbstractFieldsConfiguration
         $args = [];
         foreach ($method->getParameters() as $param) {
             // Either get existing, or create new argument
-            $arg = $argsFromAnnotations[$param->getName()] ?? new Argument();
+            $arg = $argsFromAnnotations[$param->getName()] ?? new Argument($param->getName());
             $args[$param->getName()] = $arg;
 
             $this->completeArgumentFromTypeHint($arg, $method, $param, $docBlock);

--- a/tests/AttributeBlog/Model/AbstractModel.php
+++ b/tests/AttributeBlog/Model/AbstractModel.php
@@ -16,7 +16,7 @@ use GraphQLTests\Doctrine\Blog\Types\DateTimeType;
  */
 #[ORM\MappedSuperclass]
 #[API\Sorting([PseudoRandom::class])]
-#[API\Filters(new API\Filter(field: 'id', operator: ModuloOperatorType::class, type: 'int'))]
+#[API\Filters([new API\Filter(field: 'id', operator: ModuloOperatorType::class, type: 'int')])]
 abstract class AbstractModel
 {
     /** @var int */

--- a/tests/AttributeBlog/Model/AbstractModel.php
+++ b/tests/AttributeBlog/Model/AbstractModel.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLTests\Doctrine\AttributeBlog\Model;
+
+use DateTimeImmutable;
+use Doctrine\ORM\Mapping as ORM;
+use GraphQL\Doctrine\Annotation as API;
+use GraphQLTests\Doctrine\Blog\Filtering\ModuloOperatorType;
+use GraphQLTests\Doctrine\Blog\Sorting\PseudoRandom;
+use GraphQLTests\Doctrine\Blog\Types\DateTimeType;
+
+/**
+ * Base class for all objects stored in database.
+ */
+#[ORM\MappedSuperclass]
+#[API\Sorting([PseudoRandom::class])]
+#[API\Filters(new API\Filter(field: 'id', operator: ModuloOperatorType::class, type: 'int'))]
+abstract class AbstractModel
+{
+    /** @var int */
+    #[ORM\Column(type: 'integer', options: ['unsigned' => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    protected $id;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private $creationDate;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    #[API\Field(type: DateTimeType::class)]
+    public function getCreationDate(): DateTimeImmutable
+    {
+        return $this->creationDate;
+    }
+
+    #[API\Input(type: DateTimeType::class)]
+    public function setCreationDate(DateTimeImmutable $creationDate): void
+    {
+        $this->creationDate = $creationDate;
+    }
+}

--- a/tests/AttributeBlog/Model/Post.php
+++ b/tests/AttributeBlog/Model/Post.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLTests\Doctrine\AttributeBlog\Model;
+
+use DateTimeImmutable;
+use Doctrine\ORM\Mapping as ORM;
+use GraphQL\Doctrine\Annotation as API;
+use GraphQLTests\Doctrine\AttributeBlog\Model\Special\NoInversedBy;
+use GraphQLTests\Doctrine\Blog\Filtering\SearchOperatorType;
+use GraphQLTests\Doctrine\Blog\Sorting\PostType;
+use GraphQLTests\Doctrine\Blog\Sorting\UserName;
+use GraphQLTests\Doctrine\Blog\Types\PostStatusType;
+
+/** A blog post with title and body. */
+#[ORM\Entity]
+#[API\Sorting([UserName::class, PostType::class])]
+#[API\Filters(new API\Filter(field: 'custom', operator: SearchOperatorType::class, type: 'string'))]
+final class Post extends AbstractModel
+{
+    public const STATUS_PRIVATE = 'private';
+    public const STATUS_PUBLIC = 'public';
+
+    #[ORM\Column(type: 'string', length: 50, options: ['default' => ''])]
+    private string $title = '';
+
+    #[ORM\Column(type: 'text')]
+    private string $body = '';
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private DateTimeImmutable $publicationDate;
+
+    #[API\FilterGroupCondition(type: '?GraphQLTests\Doctrine\Blog\Types\PostStatusType')]
+    #[ORM\Column(type: 'string', options: ['default' => self::STATUS_PRIVATE])]
+    private string $status = self::STATUS_PRIVATE;
+
+    #[ORM\ManyToOne(targetEntity: User::class, inversedBy: 'posts')]
+    private User $user;
+
+    #[ORM\ManyToOne(targetEntity: NoInversedBy::class)]
+    private NoInversedBy $noInversedBy;
+
+    /**
+     * Set title.
+     */
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+
+    /**
+     * Get title.
+     */
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    /**
+     * Set the body.
+     */
+    public function setBody(string $body): void
+    {
+        $this->body = $body;
+    }
+
+    /**
+     * Returns the body.
+     */
+    #[API\Field(name: 'content', description: 'The post content.')]
+    public function getBody(): string
+    {
+        return $this->body;
+    }
+
+    /**
+     * Set status.
+     */
+    #[API\Input(['type' => PostStatusType::class])]
+    public function setStatus(string $status = self::STATUS_PUBLIC): void
+    {
+        $this->status = $status;
+    }
+
+    /**
+     * Get status.
+     */
+    #[API\Field(type: PostStatusType::class)]
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    /**
+     * Set author of post.
+     */
+    public function setUser(User $user): void
+    {
+        $this->user = $user;
+    }
+
+    /**
+     * Get author of post.
+     */
+    public function getUser(): User
+    {
+        return $this->user;
+    }
+
+    /**
+     * Set date of publication.
+     */
+    public function setPublicationDate(DateTimeImmutable $publicationDate): void
+    {
+        $this->publicationDate = $publicationDate;
+    }
+
+    /**
+     * Get date of publication.
+     */
+    public function getPublicationDate(): DateTimeImmutable
+    {
+        return $this->publicationDate;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getWords(): array
+    {
+        return explode(' ', $this->getBody());
+    }
+
+    /**
+     * @param string[] $words
+     */
+    public function hasWords($words): bool
+    {
+        return count(array_diff($words, $this->getWords())) > 0;
+    }
+
+    public function isLong(int $wordLimit = 50): bool
+    {
+        return count($this->getWords()) > $wordLimit;
+    }
+
+    public function isAllowedEditing(User $user): bool
+    {
+        return $this->getUser() === $user;
+    }
+
+    /**
+     * This should be silently ignored.
+     */
+    public function setNothing(): void
+    {
+    }
+}

--- a/tests/AttributeBlog/Model/Post.php
+++ b/tests/AttributeBlog/Model/Post.php
@@ -16,7 +16,7 @@ use GraphQLTests\Doctrine\Blog\Types\PostStatusType;
 /** A blog post with title and body. */
 #[ORM\Entity]
 #[API\Sorting([UserName::class, PostType::class])]
-#[API\Filters(new API\Filter(field: 'custom', operator: SearchOperatorType::class, type: 'string'))]
+#[API\Filters([new API\Filter(field: 'custom', operator: SearchOperatorType::class, type: 'string')])]
 final class Post extends AbstractModel
 {
     public const STATUS_PRIVATE = 'private';
@@ -77,7 +77,7 @@ final class Post extends AbstractModel
     /**
      * Set status.
      */
-    #[API\Input(['type' => PostStatusType::class])]
+    #[API\Input(type: PostStatusType::class)]
     public function setStatus(string $status = self::STATUS_PUBLIC): void
     {
         $this->status = $status;

--- a/tests/AttributeBlog/Model/Special/ArrayArgument.php
+++ b/tests/AttributeBlog/Model/Special/ArrayArgument.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLTests\Doctrine\AttributeBlog\Model\Special;
+
+use Doctrine\ORM\Mapping as ORM;
+use GraphQLTests\Doctrine\AttributeBlog\Model\AbstractModel;
+
+#[ORM\Entity]
+final class ArrayArgument extends AbstractModel
+{
+    public function getWithParams(array $arg1): string
+    {
+        return __FUNCTION__;
+    }
+}

--- a/tests/AttributeBlog/Model/Special/ArrayOfEntity.php
+++ b/tests/AttributeBlog/Model/Special/ArrayOfEntity.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLTests\Doctrine\AttributeBlog\Model\Special;
+
+use Doctrine\ORM\Mapping as ORM;
+use GraphQL\Doctrine\Annotation as API;
+use GraphQLTests\Doctrine\AttributeBlog\Model\AbstractModel;
+use GraphQLTests\Doctrine\AttributeBlog\Model\User;
+
+#[ORM\Entity]
+final class ArrayOfEntity extends AbstractModel
+{
+    /**
+     * @API\Field(type="GraphQLTests\Doctrine\AttributeBlog\Model\User[]")
+     */
+    public function getUsers(): array
+    {
+        return [new User(), new User()];
+    }
+}

--- a/tests/AttributeBlog/Model/Special/CompositeIdentifier.php
+++ b/tests/AttributeBlog/Model/Special/CompositeIdentifier.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLTests\Doctrine\AttributeBlog\Model\Special;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/** This is intended to be invalid for graphql-doctrine because it has composite identifiers. */
+#[ORM\Entity]
+final class CompositeIdentifier
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    private int $id1;
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    private int $id2;
+}

--- a/tests/AttributeBlog/Model/Special/DefaultValue.php
+++ b/tests/AttributeBlog/Model/Special/DefaultValue.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLTests\Doctrine\AttributeBlog\Model\Special;
+
+use Doctrine\ORM\Mapping as ORM;
+use GraphQLTests\Doctrine\AttributeBlog\Model\AbstractModel;
+
+#[ORM\Entity]
+final class DefaultValue extends AbstractModel
+{
+    #[ORM\Column(type: 'string')]
+    private string $nameWithDefaultValueOnField = 'jane';
+
+    #[ORM\Column(type: 'string')]
+    private string $nameWithDefaultValueOnArgumentOverrideField = 'field';
+
+    public function setNameWithoutDefault(string $name): void
+    {
+    }
+
+    public function setNameWithDefaultValueOnField(string $name): void
+    {
+        $this->nameWithDefaultValueOnField = $name;
+    }
+
+    public function setNameWithDefaultValueOnArgument(string $name = 'john'): void
+    {
+    }
+
+    public function setNameWithDefaultValueOnArgumentOverrideField(string $name = 'argument'): void
+    {
+        $this->nameWithDefaultValueOnArgumentOverrideField = $name;
+    }
+
+    public function setNameWithDefaultValueOnArgumentNullable(?string $name = null): void
+    {
+    }
+
+    public function getNameWithoutDefault(string $name): string
+    {
+        return $name;
+    }
+
+    public function getNameWithDefaultValueOnArgument(string $name = 'john'): string
+    {
+        return $name;
+    }
+
+    public function getNameWithDefaultValueOnArgumentNullable(?string $name = null): string
+    {
+        return $name ?? 'foo';
+    }
+}

--- a/tests/AttributeBlog/Model/Special/ExtraArgument.php
+++ b/tests/AttributeBlog/Model/Special/ExtraArgument.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLTests\Doctrine\AttributeBlog\Model\Special;
+
+use Doctrine\ORM\Mapping as ORM;
+use GraphQL\Doctrine\Annotation as API;
+use GraphQLTests\Doctrine\AttributeBlog\Model\AbstractModel;
+
+#[ORM\Entity]
+final class ExtraArgument extends AbstractModel
+{
+    #[API\Field(args: [new API\Argument(name: 'misspelled_name')])]
+    public function getWithParams(string $arg1): string
+    {
+        return __FUNCTION__;
+    }
+}

--- a/tests/AttributeBlog/Model/Special/IgnoredGetter.php
+++ b/tests/AttributeBlog/Model/Special/IgnoredGetter.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLTests\Doctrine\AttributeBlog\Model\Special;
+
+use Doctrine\ORM\Mapping as ORM;
+use GraphQL\Doctrine\Annotation as API;
+use GraphQLTests\Doctrine\AttributeBlog\Model\AbstractModel;
+
+#[ORM\Entity]
+final class IgnoredGetter extends AbstractModel
+{
+    private string $privateProperty = 'privateProperty';
+
+    protected $protectedProperty = 'protectedProperty';
+
+    public $publicProperty = 'publicProperty';
+
+    private function getPrivate(): string
+    {
+        return __FUNCTION__;
+    }
+
+    protected function getProtected(): string
+    {
+        return __FUNCTION__;
+    }
+
+    public function getPublic(): string
+    {
+        return __FUNCTION__;
+    }
+
+    /**
+     * @param string[] $arg3
+     */
+    #[API\Field(type: 'string[]')]
+    public function getPublicWithArgs(string $arg1, int $arg2, array $arg3 = ['foo']): array
+    {
+        return [$arg1, $arg2, $arg3];
+    }
+
+    public function __call($name, $arguments): string
+    {
+        return __FUNCTION__;
+    }
+
+    public static function getStaticPublic(): string
+    {
+        return __FUNCTION__;
+    }
+
+    public function isValid(): bool
+    {
+        return true;
+    }
+
+    public function hasMoney(): bool
+    {
+        return true;
+    }
+}

--- a/tests/AttributeBlog/Model/Special/InvalidFilter.php
+++ b/tests/AttributeBlog/Model/Special/InvalidFilter.php
@@ -9,7 +9,7 @@ use GraphQL\Doctrine\Annotation as API;
 use GraphQLTests\Doctrine\AttributeBlog\Model\AbstractModel;
 
 #[ORM\Entity]
-#[API\Filters(new API\Filter(field: 'custom', operator: 'invalid_class_name', type: 'string'))]
+#[API\Filters([new API\Filter(field: 'custom', operator: 'invalid_class_name', type: 'string')])]
 final class InvalidFilter extends AbstractModel
 {
 }

--- a/tests/AttributeBlog/Model/Special/InvalidFilter.php
+++ b/tests/AttributeBlog/Model/Special/InvalidFilter.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLTests\Doctrine\AttributeBlog\Model\Special;
+
+use Doctrine\ORM\Mapping as ORM;
+use GraphQL\Doctrine\Annotation as API;
+use GraphQLTests\Doctrine\AttributeBlog\Model\AbstractModel;
+
+#[ORM\Entity]
+#[API\Filters(new API\Filter(field: 'custom', operator: 'invalid_class_name', type: 'string'))]
+final class InvalidFilter extends AbstractModel
+{
+}

--- a/tests/AttributeBlog/Model/Special/InvalidFilterGroupCondition.php
+++ b/tests/AttributeBlog/Model/Special/InvalidFilterGroupCondition.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLTests\Doctrine\AttributeBlog\Model\Special;
+
+use Doctrine\ORM\Mapping as ORM;
+use GraphQL\Doctrine\Annotation as API;
+use GraphQLTests\Doctrine\AttributeBlog\Model\AbstractModel;
+
+#[ORM\Entity]
+final class InvalidFilterGroupCondition extends AbstractModel
+{
+    #[API\FilterGroupCondition(type: '?GraphQLTests\Doctrine\AttributeBlog\Model\Post')]
+    #[ORM\Column(type: 'decimal')]
+    private $foo;
+}

--- a/tests/AttributeBlog/Model/Special/ModelWithTraits.php
+++ b/tests/AttributeBlog/Model/Special/ModelWithTraits.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLTests\Doctrine\AttributeBlog\Model\Special;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\MappedSuperclass]
+final class ModelWithTraits
+{
+    use TraitWithSortingAndFilter;
+
+    #[ORM\Column(type: 'integer', options: ['unsigned' => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    private readonly int $id;
+}

--- a/tests/AttributeBlog/Model/Special/NamespaceSupport.php
+++ b/tests/AttributeBlog/Model/Special/NamespaceSupport.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLTests\Doctrine\AttributeBlog\Model\Special;
+
+use Doctrine\ORM\Mapping as ORM;
+use GraphQLTests\Doctrine\AttributeBlog\Model\AbstractModel;
+
+#[ORM\Entity]
+final class NamespaceSupport extends AbstractModel
+{
+    private $value;
+
+    /**
+     * @return SelfSupport
+     */
+    public function getOtherModelViaPhpDoc()
+    {
+        return new SelfSupport();
+    }
+
+    /**
+     * @param SelfSupport $value
+     */
+    public function setOtherModelViaPhpDoc($value): void
+    {
+        $this->value = $value;
+    }
+}

--- a/tests/AttributeBlog/Model/Special/NoInversedBy.php
+++ b/tests/AttributeBlog/Model/Special/NoInversedBy.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLTests\Doctrine\AttributeBlog\Model\Special;
+
+use Doctrine\ORM\Mapping as ORM;
+use GraphQLTests\Doctrine\AttributeBlog\Model\AbstractModel;
+
+#[ORM\Entity]
+final class NoInversedBy extends AbstractModel
+{
+}

--- a/tests/AttributeBlog/Model/Special/NoType.php
+++ b/tests/AttributeBlog/Model/Special/NoType.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLTests\Doctrine\AttributeBlog\Model\Special;
+
+use Doctrine\ORM\Mapping as ORM;
+use GraphQLTests\Doctrine\AttributeBlog\Model\AbstractModel;
+
+#[ORM\Entity]
+final class NoType extends AbstractModel
+{
+    public function getWithoutTypeHint()
+    {
+        return __FUNCTION__;
+    }
+}

--- a/tests/AttributeBlog/Model/Special/NoTypeArgument.php
+++ b/tests/AttributeBlog/Model/Special/NoTypeArgument.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLTests\Doctrine\AttributeBlog\Model\Special;
+
+use Doctrine\ORM\Mapping as ORM;
+use GraphQLTests\Doctrine\AttributeBlog\Model\AbstractModel;
+
+#[ORM\Entity]
+final class NoTypeArgument extends AbstractModel
+{
+    public function getFoo($bar): string
+    {
+        return __FUNCTION__;
+    }
+}

--- a/tests/AttributeBlog/Model/Special/NoTypeCollection.php
+++ b/tests/AttributeBlog/Model/Special/NoTypeCollection.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLTests\Doctrine\AttributeBlog\Model\Special;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use GraphQLTests\Doctrine\AttributeBlog\Model\AbstractModel;
+
+#[ORM\Entity]
+final class NoTypeCollection extends AbstractModel
+{
+    public function getFoos(): Collection
+    {
+        return new ArrayCollection();
+    }
+}

--- a/tests/AttributeBlog/Model/Special/NoTypeInput.php
+++ b/tests/AttributeBlog/Model/Special/NoTypeInput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLTests\Doctrine\AttributeBlog\Model\Special;
+
+use Doctrine\ORM\Mapping as ORM;
+use GraphQLTests\Doctrine\AttributeBlog\Model\AbstractModel;
+
+#[ORM\Entity]
+final class NoTypeInput extends AbstractModel
+{
+    public function setFoo($bar): void
+    {
+    }
+}

--- a/tests/AttributeBlog/Model/Special/ObjectTypeArgument.php
+++ b/tests/AttributeBlog/Model/Special/ObjectTypeArgument.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLTests\Doctrine\AttributeBlog\Model\Special;
+
+use Doctrine\ORM\Mapping as ORM;
+use GraphQL\Doctrine\Annotation as API;
+use GraphQLTests\Doctrine\AttributeBlog\Model\AbstractModel;
+use GraphQLTests\Doctrine\AttributeBlog\Model\User;
+
+#[ORM\Entity]
+final class ObjectTypeArgument extends AbstractModel
+{
+    /**
+     * This is an incorrect annotation, it should be entirely deleted to let the
+     * system auto-create an input type matching the entity.
+     */
+    #[API\Field(args: [new API\Argument(name: 'user', type: User::class)])]
+    public function getWithParams(User $user): string
+    {
+        return __FUNCTION__;
+    }
+}

--- a/tests/AttributeBlog/Model/Special/SelfSupport.php
+++ b/tests/AttributeBlog/Model/Special/SelfSupport.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLTests\Doctrine\AttributeBlog\Model\Special;
+
+use Doctrine\ORM\Mapping as ORM;
+use GraphQLTests\Doctrine\AttributeBlog\Model\AbstractModel;
+
+#[ORM\Entity]
+final class SelfSupport extends AbstractModel
+{
+    private $sibling;
+
+    public function getSibling(): ?self
+    {
+        return $this->sibling;
+    }
+
+    public function setSibling(self $sibling): void
+    {
+        $this->sibling = $sibling;
+    }
+
+    /**
+     * @return null|self
+     */
+    public function getSiblingViaPhpDoc()
+    {
+        return $this->sibling;
+    }
+
+    /**
+     * @param self $sibling
+     */
+    public function setSiblingViaPhpDoc($sibling): void
+    {
+        $this->sibling = $sibling;
+    }
+}

--- a/tests/AttributeBlog/Model/Special/TraitWithSortingAndFilter.php
+++ b/tests/AttributeBlog/Model/Special/TraitWithSortingAndFilter.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLTests\Doctrine\AttributeBlog\Model\Special;
+
+use GraphQL\Doctrine\Annotation as API;
+use GraphQLTests\Doctrine\Blog\Filtering\SearchOperatorType;
+use GraphQLTests\Doctrine\Blog\Sorting\UserName;
+
+#[API\Sorting([UserName::class])]
+#[API\Filters([new API\Filter(field: 'customFromTrait', operator: SearchOperatorType::class, type: 'string')])]
+trait TraitWithSortingAndFilter
+{
+}

--- a/tests/AttributeBlog/Model/User.php
+++ b/tests/AttributeBlog/Model/User.php
@@ -28,7 +28,7 @@ final class User extends AbstractModel
     private bool $isAdministrator = false;
 
     /** @var Collection<Post> */
-    #[ORM\OneToMany(targetEntity: Post::class, mappedBy: 'user')]
+    #[ORM\OneToMany(mappedBy: 'user', targetEntity: Post::class)]
     private Collection $posts;
 
     /** @var Collection<Post> */

--- a/tests/AttributeBlog/Model/User.php
+++ b/tests/AttributeBlog/Model/User.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLTests\Doctrine\AttributeBlog\Model;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use GraphQL\Doctrine\Annotation as API;
+use GraphQLTests\Doctrine\Blog\Repository\UserRepository;
+
+/** A blog author or visitor. */
+#[ORM\Entity(repositoryClass: UserRepository::class)]
+final class User extends AbstractModel
+{
+    #[ORM\Column(name: 'custom_column_name', type: 'string', length: 50, options: ['default' => ''])]
+    private string $name = '';
+
+    #[ORM\Column(type: 'string', length: 50, nullable: true)]
+    private ?string $email = null;
+
+    #[ORM\Column(name: 'password', type: 'string', length: 255)]
+    #[API\Exclude]
+    private string $password;
+
+    #[ORM\Column(type: 'boolean', options: ['default' => false])]
+    private bool $isAdministrator = false;
+
+    /** @var Collection<Post> */
+    #[ORM\OneToMany(targetEntity: Post::class, mappedBy: 'user')]
+    private Collection $posts;
+
+    /** @var Collection<Post> */
+    #[ORM\ManyToMany(targetEntity: Post::class)]
+    private Collection $favoritePosts;
+
+    #[ORM\ManyToOne(targetEntity: self::class)]
+    private ?User $manager = null;
+
+    /**
+     * Constructor.
+     */
+    public function __construct(?int $id = null)
+    {
+        // This is a bad idea in real world, but we are just testing stuff here
+        if ($id) {
+            $this->id = $id;
+        }
+
+        $this->posts = new ArrayCollection();
+    }
+
+    /**
+     * Set name.
+     */
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * Get the user real name.
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Set a valid email or null.
+     */
+    public function setEmail(?string $email): void
+    {
+        $this->email = $email;
+    }
+
+    /**
+     * Get the validated email or null.
+     */
+    public function getEmail(): ?string
+    {
+        return $this->email;
+    }
+
+    /**
+     * Encrypt and change the user password.
+     */
+    public function setPassword(string $password): void
+    {
+        $this->password = password_hash($password, PASSWORD_DEFAULT) ?: '';
+    }
+
+    /**
+     * Returns the hashed password.
+     *
+     * @API\Exclude
+     */
+    public function getPassword(): string
+    {
+        return $this->password;
+    }
+
+    /**
+     * Set whether the user is an administrator.
+     *
+     * @API\Exclude
+     */
+    public function setIsAdministrator(bool $isAdministrator): void
+    {
+        $this->isAdministrator = $isAdministrator;
+    }
+
+    /**
+     * Get whether the user is an administrator.
+     */
+    public function isAdministrator(): bool
+    {
+        return $this->isAdministrator;
+    }
+
+    /**
+     * Returns all posts of the specified status.
+     *
+     * @param null|string $status the status of posts as defined in \GraphQLTests\Doctrine\AttributeBlog\Model\Post
+     */
+    #[API\Field(args: [new API\Argument(name: 'status', type: '?GraphQLTests\Doctrine\Blog\Types\PostStatusType')])]
+    public function getPosts(?string $status = Post::STATUS_PUBLIC): Collection
+    {
+        // Return unfiltered collection
+        if ($status === null) {
+            return $this->posts;
+        }
+
+        return $this->posts->filter(fn (Post $post) => $post->getStatus() === $status);
+    }
+
+    #[API\Field(type: 'GraphQLTests\Doctrine\AttributeBlog\Model\Post[]', args: [
+        new API\Argument(name: 'ids', type: 'id[]'),
+    ])]
+    public function getPostsWithIds(array $ids): Collection
+    {
+        return $this->posts->filter(fn (Post $post) => in_array($post->getId(), $ids, true));
+    }
+
+    public function setManager(?self $manager): void
+    {
+        $this->manager = $manager;
+    }
+
+    public function getManager(): ?self
+    {
+        return $this->manager;
+    }
+}

--- a/tests/EntityManagerTrait.php
+++ b/tests/EntityManagerTrait.php
@@ -21,4 +21,11 @@ trait EntityManagerTrait
         $conn = ['url' => 'sqlite:///:memory:'];
         $this->entityManager = EntityManager::create($conn, $config);
     }
+
+    private function setUpAttributeEntityManager(): void
+    {
+        $config = Setup::createAttributeMetadataConfiguration([__DIR__ . '/AttributeBlog/Model'], true);
+        $conn = ['url' => 'sqlite:///:memory:'];
+        $this->entityManager = EntityManager::create($conn, $config);
+    }
 }

--- a/tests/Factory/MetadataReader/AttributeReaderAdapterTest.php
+++ b/tests/Factory/MetadataReader/AttributeReaderAdapterTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLTests\Doctrine\Factory\MetadataReader;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Driver\AttributeDriver;
+use Doctrine\ORM\Mapping\Driver\AttributeReader;
+use Doctrine\ORM\Mapping\Entity;
+use GraphQL\Doctrine\Factory\MetadataReader\AttributeReaderAdapter;
+use GraphQLTests\Doctrine\AttributeBlog\Model\Post;
+use GraphQLTests\Doctrine\TypesTrait;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionProperty;
+use RuntimeException;
+
+class AttributeReaderAdapterTest extends TestCase
+{
+    use TypesTrait {
+        setUpWithAttributes as typeSetup;
+    }
+
+    private AttributeReaderAdapter $chainAdapter;
+
+    protected function setUp(): void
+    {
+        $this->typeSetup();
+
+        $config = $this->entityManager->getConfiguration();
+        $mappingDriver = $config->getMetadataDriverImpl();
+        if (!$mappingDriver instanceof AttributeDriver) {
+            throw new RuntimeException('invalid runtime configuration: expected the metadata driver to be a ' . AttributeDriver::class);
+        }
+        /** @var AttributeReader $attributeReader */
+        $attributeReader = $mappingDriver->getReader();
+        $this->chainAdapter = new AttributeReaderAdapter($attributeReader);
+    }
+
+    public function testGetClassAnnotations(): void
+    {
+        self::assertNotEmpty($this->chainAdapter->getClassAnnotations(new ReflectionClass(Post::class)));
+    }
+
+    public function testGetClassAnnotation(): void
+    {
+        self::assertNotNull($this->chainAdapter->getClassAnnotation(new ReflectionClass(Post::class), Entity::class));
+    }
+
+    public function testGetMethodAnnotations(): void
+    {
+        self::assertNotEmpty($this->chainAdapter->getMethodAnnotations(new ReflectionMethod(Post::class, 'getBody')));
+    }
+
+    public function testGetMethodAnnotation(): void
+    {
+        self::assertNotNull($this->chainAdapter->getMethodAnnotations(new ReflectionMethod(Post::class, 'getBody')));
+    }
+
+    public function testGetPropertyAnnotations(): void
+    {
+        self::assertNotEmpty($this->chainAdapter->getPropertyAnnotations(new ReflectionProperty(Post::class, 'body')));
+    }
+
+    public function testGetPropertyAnnotation(): void
+    {
+        self::assertNotNull($this->chainAdapter->getPropertyAnnotation(
+            new ReflectionProperty(Post::class, 'body'),
+            Column::class
+        ));
+    }
+}

--- a/tests/Factory/Type/EntityIDTypeFactoryWithAttributesTest.php
+++ b/tests/Factory/Type/EntityIDTypeFactoryWithAttributesTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLTests\Doctrine\Factory\Type;
+
+use GraphQL\Doctrine\Definition\EntityIDType;
+use GraphQL\Doctrine\Factory\Type\EntityIDTypeFactory;
+use GraphQL\Doctrine\Types;
+use GraphQLTests\Doctrine\AttributeBlog\Model\Special\CompositeIdentifier;
+use GraphQLTests\Doctrine\AttributeBlog\Model\User;
+use GraphQLTests\Doctrine\EntityManagerTrait;
+use PHPUnit\Framework\TestCase;
+
+final class EntityIDTypeFactoryWithAttributesTest extends TestCase
+{
+    use EntityManagerTrait;
+
+    private EntityIDTypeFactory $entityIDTypeFactory;
+
+    protected function setUp(): void
+    {
+        $this->setUpAttributeEntityManager();
+
+        $types = new Types($this->entityManager);
+        $this->entityIDTypeFactory = new EntityIDTypeFactory($types, $this->entityManager);
+    }
+
+    public function testCreateEntityIDType(): void
+    {
+        self::assertInstanceOf(EntityIDType::class, $this->entityIDTypeFactory->create(User::class, 'foo'));
+    }
+
+    public function testEntityWithCompositeIdentifierMustThrow(): void
+    {
+        $this->expectExceptionMessage('Entities with composite identifiers are not supported by graphql-doctrine. The entity `GraphQLTests\Doctrine\AttributeBlog\Model\Special\CompositeIdentifier` cannot be used as input type.');
+        $this->entityIDTypeFactory->create(CompositeIdentifier::class, 'foo');
+    }
+}

--- a/tests/TypesTrait.php
+++ b/tests/TypesTrait.php
@@ -49,9 +49,28 @@ trait TypesTrait
         $this->types = new Types($this->entityManager, $customTypes);
     }
 
+    public function setUpWithAttributes(): void
+    {
+        $this->setUpAttributeEntityManager();
+
+        $customTypes = new ServiceManager([
+            'invokables' => [
+                BooleanType::class => BooleanType::class,
+                DateTimeImmutable::class => DateTimeType::class,
+                stdClass::class => CustomType::class,
+                'PostStatus' => PostStatusType::class,
+            ],
+            'aliases' => [
+                'datetime_immutable' => DateTimeImmutable::class, // Declare alias for Doctrine type to be used for filters
+            ],
+        ]);
+
+        $this->types = new Types($this->entityManager, $customTypes);
+    }
+
     private function assertType(string $expectedFile, Type $type): void
     {
-        $actual = SchemaPrinter::printType($type) . PHP_EOL;
+        $actual = SchemaPrinter::printType($type) . "\n";
         self::assertStringEqualsFile($expectedFile, $actual, 'Should equals expectation from: ' . $expectedFile);
     }
 


### PR DESCRIPTION
**Disclaimer first:** It may be the case, that by some magic unknown to me, this library already support accessing the attribute based doctrine metadata, and I was just not smart enough to get it to work. If thats the case, I am sorry for wasting your time.

This should allow users to use this with the Doctrine AttributeDriver for metadata, instead of using the AnnotationDriver. This requires the that all `GraphQL\Doctrine\Annotation`s are written as annotations as well, though.
The alternative would be to use two readers, one that reads annotations and one that reads attributes, and fall back to one of the if the other does not yield a result.

There are a few quirks in this version that I hope to fix in the next commits, but its getting late... 

First, the IDE complaints if we use the named arguments in attributes, that do not have constructor parameters with that name. Makes sense, I guess its Doctrine magic that makes that work at the moment, but we may not want to rely on that. As far as I can see there are two possible routes to fix that: 
Sacrefice the nice syntax of `#[API\Field(args: [new API\Argument(name: 'status', type: '?string')])]`
 and go with `#[API\Field(args: [new API\Argument(['name' => 'status', 'type' => '?string'])])]`, which uses the default constructor and seems to work fine. But IMHO its ugly, it does not support IDE type hinting, and we'd also give up type checking.
Not my prefered option. 

The other way would be, to give all annotations a constructor that works for them, add the `@NamedArgumentConstructor` annotation, and everything should be fine. This worked for most of them, but `Field` gave me some pain. I did not went into that rabbit hole (yet) but it seems that the type hints on that class lie and it may also be re-used to hold some other DTOs? 

More research is required. 

Also, the new test are kind of messy. I did not want to restructure to much, but I also wanted to have at least some basic coverage for the first step. Thats why the current state is just some copy & paste with a coat of sugar. This needs to be improved. 

Lastly, the AttributeReader we wrap here to pretent that its an Annotation\Reader is marked as `@Internal` by doctrine, so usign it directly does not seem advisable. Not sure if we have a good alterantive over this, short of copy-pasting it. 